### PR TITLE
Fixed the vm, volume and security_group parser as well as the collector specs

### DIFF
--- a/lib/topological_inventory/amazon/parser/security_group.rb
+++ b/lib/topological_inventory/amazon/parser/security_group.rb
@@ -5,6 +5,7 @@ module TopologicalInventory::Amazon
         stack_id = get_from_tags(sg.tags, "aws:cloudformation:stack-id")
         stack    = lazy_find(:orchestration_stacks, :source_ref => stack_id) if stack_id
         network  = lazy_find(:networks, :source_ref => sg.vpc_id) if sg.vpc_id
+        network_id = sg.vpc_id if network
 
         collections[:security_groups].data << TopologicalInventoryIngressApiClient::SecurityGroup.new(
           :source_ref          => sg.group_id,
@@ -17,7 +18,7 @@ module TopologicalInventory::Amazon
           :source_region       => lazy_find(:source_regions, :source_ref => scope[:region]),
           :subscription        => lazy_find_subscription(scope),
           :orchestration_stack => stack,
-          :network             => network,
+          :network_id          => network_id
         )
 
         parse_tags(:security_groups, sg.group_id, sg.tags)

--- a/lib/topological_inventory/amazon/parser/vm.rb
+++ b/lib/topological_inventory/amazon/parser/vm.rb
@@ -17,7 +17,7 @@ module TopologicalInventory::Amazon
           :mac_addresses        => parse_network(instance)[:mac_addresses],
           :source_region        => lazy_find(:source_regions, :source_ref => scope[:region]),
           :subscription         => lazy_find_subscription(scope),
-          :orchestration_stacks => stack,
+          :orchestration_stack  => stack
         )
 
         collections[:vms].data << vm

--- a/lib/topological_inventory/amazon/parser/volume.rb
+++ b/lib/topological_inventory/amazon/parser/volume.rb
@@ -14,7 +14,7 @@ module TopologicalInventory::Amazon
           :volume_type          => lazy_find(:volume_types, :source_ref => data.volume_type),
           :source_region        => lazy_find(:source_regions, :source_ref => scope[:region]),
           :subscription         => lazy_find_subscription(scope),
-          :orchestration_stacks => stack,
+          :orchestration_stack  => stack
         )
 
         collections[:volumes].data << volume

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -698,6 +698,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
                                                           :ip_ranges   => [{:cidr_ip => "0.0.0.0/0"}],
                                                           :to_port     => 0}]},
            :name          => "security_group_0",
+           :network_id    => "vpc_0",
            :source_ref    => "security_group_0",
            :source_region =>
                              {:inventory_collection_name => :source_regions,
@@ -715,6 +716,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
                                                           :ip_ranges   => [{:cidr_ip => "0.0.0.0/0"}],
                                                           :to_port     => 0}]},
            :name          => "security_group_0",
+           :network_id    => "vpc_0",
            :source_ref    => "security_group_0",
            :source_region =>
                              {:inventory_collection_name => :source_regions,
@@ -1035,7 +1037,7 @@ RSpec.describe TopologicalInventory::Amazon::Collector do
   end
 
   def format_hash(entity, parser, ignore: nil)
-    hash = parser.collections[entity].data.map(&:to_hash)
+    hash = parser.collections[entity].data.map { |h| h.to_hash.compact }
     if ignore
       hash = hash.map { |x| x.except(*ignore) }
     end


### PR DESCRIPTION

Saw some inconsistencies with the Ingress API classes:
- updated the vm and volume parsers to define orchestration_stack instead of orchestration_stacks.
- updated the security_group parser to define network_id instead of network.

Updated the collector_spec to ignore keys with nil values.
