### PR TITLE
Standalone mode switch for multisource ThreadPool

### DIFF
--- a/lib/topological_inventory/amazon/collector.rb
+++ b/lib/topological_inventory/amazon/collector.rb
@@ -22,10 +22,12 @@ module TopologicalInventory
       include Amazon::Collector::Pricing
       include Amazon::Collector::ServiceCatalog
 
-      def initialize(source, access_key_id, secret_access_key, sub_account_role, metrics, default_limit: 1_000, poll_time: 5)
+      def initialize(source, access_key_id, secret_access_key, sub_account_role, metrics,
+                     default_limit: 1_000, poll_time: 30, standalone_mode: true)
         super(source,
-              :default_limit => default_limit,
-              :poll_time     => poll_time)
+              :default_limit   => default_limit,
+              :poll_time       => poll_time,
+              :standalone_mode => standalone_mode)
 
         self.secret_access_key = secret_access_key
         self.sub_account_role  = sub_account_role
@@ -51,7 +53,7 @@ module TopologicalInventory
             logger.error(e)
             metrics.record_error
           ensure
-            sleep(30)
+            standalone_mode ? sleep(poll_time) : stop
           end
         end
       end

--- a/lib/topological_inventory/amazon/collectors_pool.rb
+++ b/lib/topological_inventory/amazon/collectors_pool.rb
@@ -6,7 +6,7 @@ module TopologicalInventory::Amazon
   class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
-    def initialize(config_name, metrics, poll_time: 10)
+    def initialize(config_name, metrics)
       super
     end
 
@@ -29,7 +29,7 @@ module TopologicalInventory::Amazon
 
     def new_collector(source, secret)
       # TODO(lsmola) pass correct sub_account_role from source's extra
-      TopologicalInventory::Amazon::Collector.new(source.source, secret['username'], secret['password'], nil, metrics)
+      TopologicalInventory::Amazon::Collector.new(source.source, secret['username'], secret['password'], nil, metrics, :standalone_mode => false)
     end
   end
 end


### PR DESCRIPTION
MultiSource mode will schedule running of collectors. It means in this mode collecting isn't run i the loop.

---

-  **depends on [mutual]** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/11