### PR TITLE
Log unsupported operation

### DIFF
--- a/lib/topological_inventory/amazon/operations/processor.rb
+++ b/lib/topological_inventory/amazon/operations/processor.rb
@@ -19,22 +19,26 @@ module TopologicalInventory
         end
 
         def process
-          logger.info("Processing #{model}##{method} [#{params}]...")
+          logger.info(status_log_msg)
 
           impl = Operations.const_get(model).new(params, identity) if Operations.const_defined?(model)
-          unless impl
-            logger.error("#{model}.#{method} is not implemented")
-            return
-          end
+          if impl&.respond_to?(method)
+            result = impl.send(method)
 
-          result = impl.send(method)
-          logger.info("Processing #{model}##{method} [#{params}]...Complete")
-          result
+            logger.info(status_log_msg("Complete"))
+            result
+          else
+            logger.warn(status_log_msg("Not Implemented!"))
+          end
         end
 
         private
 
         attr_accessor :message, :identity, :model, :method, :params
+
+        def status_log_msg(status = nil)
+          "Processing #{model}##{method} [#{params}]...#{status}"
+        end
       end
     end
   end


### PR DESCRIPTION
Unknown operations sent to operations workers are now logged as Warn:"Not implemented" (tasks not used yet) (also unifying log with other workers)