### PR TITLE
If a source is configured only for cost don't mark it unavailable

### DIFF
--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -45,7 +45,9 @@ module TopologicalInventory
           endpoint_authentications = api_client.list_endpoint_authentications(endpoint.id.to_s).data || []
           return STATUS_UNAVAILABLE if endpoint_authentications.empty?
 
-          auth_id = endpoint_authentications.first.id
+          auth_id = endpoint_authentications.detect { |a| a.authtype == "access_key_secret_key" }&.id
+          return if auth_id.nil?
+
           auth = Core::AuthenticationRetriever.new(auth_id, identity).process
           return STATUS_UNAVAILABLE unless auth
 


### PR DESCRIPTION
If a source doesn't have access_key_secret_key credentials it doesn't mean it is unavailable, just that it isn't configured for topological inventory.

Fixes https://github.com/RedHatInsights/sources-api/issues/174