### PR TITLE
Availability check based on providers-common gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
-gem "sources-api-client", "~> 1.0"
+gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.2"
+gem "topological_inventory-providers-common", "~> 1.0.5"
 group :test, :development do
   gem "rspec"
   gem 'rubocop',             '~>0.69.0', :require => false

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -1,81 +1,32 @@
-require "sources-api-client"
-require "active_support/core_ext/numeric/time"
+require "topological_inventory/amazon/logging"
+require "topological_inventory/providers/common/operations/source"
 require "topological_inventory/amazon/connection"
-require "topological_inventory/amazon/operations/core/authentication_retriever"
 
 module TopologicalInventory
   module Amazon
     module Operations
-      class Source
+      class Source < TopologicalInventory::Providers::Common::Operations::Source
         include Logging
-        STATUS_AVAILABLE, STATUS_UNAVAILABLE = %w[available unavailable].freeze
-
-        attr_accessor :params, :context, :source_id
-
-        def initialize(params = {}, request_context = nil)
-          @params  = params
-          @context = request_context
-          @source_id = nil
-        end
-
-        def availability_check
-          source_id = params["source_id"]
-          unless source_id
-            logger.error("Missing source_id for the availability_check request")
-            return
-          end
-
-          source = SourcesApiClient::Source.new
-          source.availability_status = connection_check(source_id)
-
-          begin
-            api_client.update_source(source_id, source)
-          rescue SourcesApiClient::ApiError => e
-            logger.error("Failed to update Source id:#{source_id} - #{e.message}")
-          end
-          logger.info("Source#availability_check completed: Source #{source_id} is #{source.availability_status}")
-        end
 
         private
 
         def connection_check(source_id)
-          endpoints = api_client.list_source_endpoints(source_id)&.data || []
-          endpoint = endpoints.find(&:default)
-          return STATUS_UNAVAILABLE unless endpoint
-
-          endpoint_authentications = api_client.list_endpoint_authentications(endpoint.id.to_s).data || []
-          return STATUS_UNAVAILABLE if endpoint_authentications.empty?
-
-          auth_id = endpoint_authentications.detect { |a| a.authtype == "access_key_secret_key" }&.id
-          return if auth_id.nil?
-
-          auth = Core::AuthenticationRetriever.new(auth_id, identity).process
-          return STATUS_UNAVAILABLE unless auth
-
           ec2_connection = TopologicalInventory::Amazon::Connection.ec2(
-            :access_key_id     => auth.username,
-            :secret_access_key => auth.password,
+            :access_key_id     => authentication.username,
+            :secret_access_key => authentication.password,
             :region            => region
           )
 
           ec2_connection.client.describe_regions.regions
 
-          STATUS_AVAILABLE
+          [STATUS_AVAILABLE, nil]
         rescue => e
-          logger.error("Failed to connect to Source id:#{source_id} - #{e.message}")
-          STATUS_UNAVAILABLE
+          logger.availability_check("Failed to connect to Source id:#{source_id} - #{e.message}", :error)
+          [STATUS_UNAVAILABLE, e.message]
         end
 
-        def identity
-          @identity ||= { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => params["external_tenant"], "user" => { "is_org_admin" => true }}}.to_json) }
-        end
-
-        def api_client
-          @api_client ||= begin
-            api_client = SourcesApiClient::ApiClient.new
-            api_client.default_headers.merge!(identity)
-            SourcesApiClient::DefaultApi.new(api_client)
-          end
+        def authentication
+          @authentication ||= api_client.fetch_authentication(source_id, endpoint, 'access_key_secret_key')
         end
 
         def region

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -1,34 +1,6 @@
-require "sources-api-client"
 require "topological_inventory/amazon/operations/source"
+require File.join(Gem::Specification.find_by_name("topological_inventory-providers-common").gem_dir, "spec/support/shared/availability_check.rb")
 
 RSpec.describe(TopologicalInventory::Amazon::Operations::Source) do
-  describe "availability_check" do
-    let(:host_url) { "https://cloud.redhat.com" }
-    let(:external_tenant) { "11001" }
-    let(:identity) do
-      { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => external_tenant, "user" => { "is_org_admin" => true } } }.to_json) }
-    end
-    let(:headers) { {"Content-Type" => "application/json"}.merge(identity) }
-
-    it "makes a patch request to update the availability_status of a source" do
-      source_id = "201"
-      payload =
-        {
-          "params" => {
-            "source_id"       => source_id,
-            "external_tenant" => external_tenant,
-            "timestamp"       => Time.now.utc
-          }
-        }
-
-      stub_request(:get, "https://cloud.redhat.com/api/sources/v1.0/sources/#{source_id}/endpoints")
-        .with(:headers => headers)
-        .to_return(:status => 200, :body => "", :headers => {})
-      stub_request(:patch, "https://cloud.redhat.com/api/sources/v1.0/sources/#{source_id}")
-        .with(:body => {"availability_status" => "unavailable"}.to_json, :headers => headers)
-        .to_return(:status => 200, :body => "", :headers => {})
-
-      described_class.new(payload["params"]).availability_check
-    end
-  end
+  it_behaves_like "availability_check" # in providers-common
 end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/206

This PR moves Source#availability_check from AnsibleTower to providers-common. 

---

**Depends on**:

* [x] https://github.com/RedHatInsights/topological_inventory-amazon/pull/63
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/25
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/28
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/33
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/34
---

[TPINVTRY-944](https://projects.engineering.redhat.com/browse/TPINVTRY-944)