### PR TITLE
Operations refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.10"
+gem "topological_inventory-providers-common", "~> 2.0.0"
 group :test, :development do
   gem "rspec"
   gem 'rubocop',             '~>0.69.0', :require => false

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -26,7 +26,7 @@ module TopologicalInventory
         end
 
         def authentication
-          @authentication ||= api_client.fetch_authentication(source_id, endpoint, 'access_key_secret_key')
+          @authentication ||= sources_api.fetch_authentication(source_id, endpoint, 'access_key_secret_key')
         end
 
         def region


### PR DESCRIPTION
Unifying names changed `api_client` to `sources_api`

---

**Depends on**:

- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/52
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/53

---

[RHCLOUD-9343](https://issues.redhat.com/browse/RHCLOUD-9343) 