### PR TITLE
Custom metrics for operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 2.1.0"
+gem "topological_inventory-providers-common", "~> 2.1.1"
 group :test, :development do
   gem "rspec"
   gem "rubocop",             "~> 1.0.0", :require => false

--- a/bin/amazon-operations
+++ b/bin/amazon-operations
@@ -48,7 +48,7 @@ Signal.trap("TERM") do
 end
 
 begin
-  operations_worker = TopologicalInventory::Amazon::Operations::Worker.new(:metrics => metrics)
+  operations_worker = TopologicalInventory::Amazon::Operations::Worker.new(metrics)
   operations_worker.run
 rescue => err
   puts err

--- a/bin/amazon-operations
+++ b/bin/amazon-operations
@@ -2,23 +2,53 @@
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
 require "bundler/setup"
+require "optimist"
 require "topological_inventory/amazon/operations/worker"
+require "topological_inventory/amazon/operations/metrics"
 
-queue_host = ENV["QUEUE_HOST"] || "localhost"
-queue_port = ENV["QUEUE_PORT"] || 9092
+def parse_args
+  Optimist.options do
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
+        :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
 
-SourcesApiClient.configure do |config|
-  config.scheme = ENV["SOURCES_SCHEME"]
-  config.host   = "#{ENV["SOURCES_HOST"]}:#{ENV["SOURCES_PORT"]}"
+    opt :queue_host, "Kafka messaging: hostname or IP", :type => :string, :default => ENV["QUEUE_HOST"] || "localhost"
+    opt :queue_port, "Kafka messaging: port", :type => :integer, :default => (ENV["QUEUE_PORT"] || 9092).to_i
+
+    opt :sources_scheme, "Sources API scheme", :type => :string, :default => ENV["SOURCES_SCHEME"] || "http"
+    opt :sources_host, "Sources API host name", :type => :string, :default => ENV["SOURCES_HOST"]
+    opt :sources_port, "Sources API port", :type => :integer, :default => ENV["SOURCES_PORT"].to_i
+  end
 end
 
+def check_args(args)
+  %i[queue_host queue_port
+     sources_scheme sources_host sources_port].each do |arg|
+    Optimist.die arg, "can't be blank" if args[arg].blank?
+    Optimist.die arg, "can't be zero" if arg.to_s.index('port').present? && args[arg].zero?
+  end
+end
+
+args = parse_args
+check_args(args)
+
+SourcesApiClient.configure do |config|
+  config.scheme = args[:sources_scheme] || "http"
+  config.host   = "#{args[:sources_host]}:#{args[:sources_port]}"
+end
 TopologicalInventory::Amazon::MessagingClient.configure do |config|
-  config.queue_host = queue_host
-  config.queue_port = queue_port
+  config.queue_host = args[:queue_host]
+  config.queue_port = args[:queue_port]
+end
+
+metrics = TopologicalInventory::Amazon::Operations::Metrics.new(args[:metrics_port])
+
+Signal.trap("TERM") do
+  metrics.stop_server
+  exit
 end
 
 begin
-  operations_worker = TopologicalInventory::Amazon::Operations::Worker.new
+  operations_worker = TopologicalInventory::Amazon::Operations::Worker.new(:metrics => metrics)
   operations_worker.run
 rescue => err
   puts err

--- a/lib/topological_inventory/amazon/operations/metrics.rb
+++ b/lib/topological_inventory/amazon/operations/metrics.rb
@@ -1,0 +1,17 @@
+require 'topological_inventory/providers/common/metrics'
+
+module TopologicalInventory
+  module Amazon
+    module Operations
+      class Metrics < TopologicalInventory::Providers::Common::Metrics
+        def initialize(port = 9394)
+          super(port)
+        end
+
+        def default_prefix
+          "topological_inventory_amazon_operations_"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/amazon/operations/processor.rb
+++ b/lib/topological_inventory/amazon/operations/processor.rb
@@ -1,57 +1,15 @@
 require "topological_inventory/amazon/logging"
-require "topological_inventory/providers/common/mixins/statuses"
+require "topological_inventory/amazon/operations/source"
+require "topological_inventory/providers/common/operations/processor"
 
 module TopologicalInventory
   module Amazon
     module Operations
-      class Processor
+      class Processor < TopologicalInventory::Providers::Common::Operations::Processor
         include Logging
-        include TopologicalInventory::Providers::Common::Mixins::Statuses
 
-        def self.process!(message, metrics)
-          new(message, metrics).process
-        end
-
-        def initialize(message, metrics)
-          self.message = message
-          self.metrics = metrics
-          self.model, self.method = message.message.split(".")
-
-          self.params   = message.payload["params"]
-          self.identity = message.payload["request_context"]
-        end
-
-        def process
-          logger.info(status_log_msg)
-
-          impl = Operations.const_get(model).new(params, identity, metrics) if Operations.const_defined?(model)
-          if impl&.respond_to?(method)
-            with_time_measure do
-              result = impl.send(method)
-
-              logger.info(status_log_msg("Complete"))
-              result
-            end
-          else
-            logger.warn(status_log_msg("Not Implemented!"))
-            operation_status[:not_implemented]
-          end
-        end
-
-        private
-
-        attr_accessor :message, :identity, :model, :method, :metrics, :params
-
-        def with_time_measure
-          if metrics.present?
-            metrics.record_operation_time(message.message) { yield }
-          else
-            yield
-          end
-        end
-
-        def status_log_msg(status = nil)
-          "Processing #{model}##{method} [#{params}]...#{status}"
+        def operation_class
+          "#{Operations}::#{model}".safe_constantize
         end
       end
     end

--- a/lib/topological_inventory/amazon/operations/processor.rb
+++ b/lib/topological_inventory/amazon/operations/processor.rb
@@ -44,7 +44,7 @@ module TopologicalInventory
 
         def with_time_measure
           if metrics.present?
-            metrics.record_operation_time("#{model}.#{method}") { yield }
+            metrics.record_operation_time(message.message) { yield }
           else
             yield
           end

--- a/lib/topological_inventory/amazon/operations/processor.rb
+++ b/lib/topological_inventory/amazon/operations/processor.rb
@@ -1,17 +1,20 @@
 require "topological_inventory/amazon/logging"
+require "topological_inventory/providers/common/mixins/statuses"
 
 module TopologicalInventory
   module Amazon
     module Operations
       class Processor
         include Logging
+        include TopologicalInventory::Providers::Common::Mixins::Statuses
 
-        def self.process!(message)
-          new(message).process
+        def self.process!(message, metrics)
+          new(message, metrics).process
         end
 
-        def initialize(message)
+        def initialize(message, metrics)
           self.message = message
+          self.metrics = metrics
           self.model, self.method = message.message.split(".")
 
           self.params   = message.payload["params"]
@@ -21,20 +24,31 @@ module TopologicalInventory
         def process
           logger.info(status_log_msg)
 
-          impl = Operations.const_get(model).new(params, identity) if Operations.const_defined?(model)
+          impl = Operations.const_get(model).new(params, identity, metrics) if Operations.const_defined?(model)
           if impl&.respond_to?(method)
-            result = impl.send(method)
+            with_time_measure do
+              result = impl.send(method)
 
-            logger.info(status_log_msg("Complete"))
-            result
+              logger.info(status_log_msg("Complete"))
+              result
+            end
           else
             logger.warn(status_log_msg("Not Implemented!"))
+            operation_status[:not_implemented]
           end
         end
 
         private
 
-        attr_accessor :message, :identity, :model, :method, :params
+        attr_accessor :message, :identity, :model, :method, :metrics, :params
+
+        def with_time_measure
+          if metrics.present?
+            metrics.record_operation_time("#{model}.#{method}") { yield }
+          else
+            yield
+          end
+        end
 
         def status_log_msg(status = nil)
           "Processing #{model}##{method} [#{params}]...#{status}"

--- a/lib/topological_inventory/amazon/operations/source.rb
+++ b/lib/topological_inventory/amazon/operations/source.rb
@@ -25,8 +25,13 @@ module TopologicalInventory
           [STATUS_UNAVAILABLE, e.message]
         end
 
+        # called only for endpoint_connection_check()
         def authentication
           @authentication ||= sources_api.fetch_authentication(source_id, endpoint, 'access_key_secret_key')
+        rescue => e
+          metrics&.record_error(:sources_api)
+          logger.error_ext(operation, "Failed to fetch Authentication for Source #{source_id}: #{e.message}")
+          nil
         end
 
         def region

--- a/lib/topological_inventory/amazon/operations/worker.rb
+++ b/lib/topological_inventory/amazon/operations/worker.rb
@@ -1,7 +1,6 @@
 require "topological_inventory/amazon/logging"
 require "topological_inventory/amazon/messaging_client"
 require "topological_inventory/amazon/operations/processor"
-require "topological_inventory/amazon/operations/source"
 require "topological_inventory/providers/common/mixins/statuses"
 require "topological_inventory/providers/common/operations/health_check"
 
@@ -12,7 +11,7 @@ module TopologicalInventory
         include Logging
         include TopologicalInventory::Providers::Common::Mixins::Statuses
 
-        def initialize(metrics:)
+        def initialize(metrics = nil)
           self.metrics = metrics
         end
 

--- a/lib/topological_inventory/amazon/operations/worker.rb
+++ b/lib/topological_inventory/amazon/operations/worker.rb
@@ -42,10 +42,10 @@ module TopologicalInventory
 
         def process_message(message)
           result = Processor.process!(message, metrics)
-          metrics&.record_operation(message, result)
+          metrics&.record_operation(message.message, :status => result)
         rescue => e
           logger.error("#{e}\n#{e.backtrace.join("\n")}")
-          metrics&.record_operation(message, operation_status[:error])
+          metrics&.record_operation(message.message, :status => operation_status[:error])
         ensure
           message.ack
           TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file

--- a/spec/operations/processor_spec.rb
+++ b/spec/operations/processor_spec.rb
@@ -1,6 +1,26 @@
 require "topological_inventory/amazon/operations/processor"
 
 RSpec.describe TopologicalInventory::Amazon::Operations::Processor do
+  let(:message) { double("ManageIQ::Messaging::ReceivedMessage", :message => operation_name, :payload => payload) }
+  let(:operation_name) { 'Testing.operation' }
+  let(:params) { {'source_id' => 1, 'external_tenant' => '12345'} }
+  let(:payload) { {"params" => params, "request_context" => double('request_context')} }
+
+  subject { described_class.new(message, nil) }
+
   describe "#process" do
+    context "Source.availability_check task" do
+      let(:source_class) { TopologicalInventory::Amazon::Operations::Source }
+      let(:operation_name) { 'Source.availability_check' }
+
+      it "runs availability check" do
+        source = source_class.new(params)
+        allow(source_class).to receive(:new).and_return(source)
+
+        expect(source).to receive(:availability_check)
+
+        subject.process
+      end
+    end
   end
 end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -2,26 +2,50 @@ require "topological_inventory/amazon/operations/worker"
 
 RSpec.describe TopologicalInventory::Amazon::Operations::Worker do
   describe "#run" do
-    let(:subject) { described_class.new }
-    let(:client)  { double("ManageIQ::Messaging::Client") }
+    let(:client) { double("ManageIQ::Messaging::Client") }
+    let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
+    let(:metrics) { double("Metrics", :record_operation => nil) }
+    let(:operation) { 'Test.operation' }
+    let(:subject) { described_class.new(:metrics => metrics) }
 
     before do
       TopologicalInventory::Amazon::MessagingClient.class_variable_set(:@@default, nil)
       allow(subject).to receive(:client).and_return(client)
       allow(client).to receive(:close)
+      allow(TopologicalInventory::Providers::Common::Operations::HealthCheck).to receive(:touch_file)
+      allow(message).to receive_messages(:ack => nil, :message => operation)
     end
 
     it "calls subscribe_topic on the right queue" do
       operations_topic = "platform.topological-inventory.operations-amazon"
-
-      message = double("ManageIQ::Messaging::ReceivedMessage")
-      allow(message).to receive(:ack)
+      result = double("result")
 
       expect(client).to receive(:subscribe_topic)
         .with(hash_including(:service => operations_topic)).and_yield(message)
       expect(TopologicalInventory::Amazon::Operations::Processor)
-        .to receive(:process!).with(message)
+        .to receive(:process!).with(message, metrics).and_return(result)
+
       subject.run
+    end
+
+    context ".metrics" do
+      it "records successful operation" do
+        result = subject.operation_status[:success]
+
+        allow(TopologicalInventory::Amazon::Operations::Processor).to receive(:process!).and_return(result)
+        expect(metrics).to receive(:record_operation).with(operation, :status => result)
+
+        subject.send(:process_message, message)
+      end
+
+      it "records exception" do
+        result = subject.operation_status[:error]
+
+        allow(TopologicalInventory::Amazon::Operations::Processor).to receive(:process!).and_raise("Test Exception!")
+        expect(metrics).to receive(:record_operation).with(operation, :status => result)
+
+        subject.send(:process_message, message)
+      end
     end
   end
 end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TopologicalInventory::Amazon::Operations::Worker do
     let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
     let(:metrics) { double("Metrics", :record_operation => nil) }
     let(:operation) { 'Test.operation' }
-    let(:subject) { described_class.new(:metrics => metrics) }
+    let(:subject) { described_class.new(metrics) }
 
     before do
       TopologicalInventory::Amazon::MessagingClient.class_variable_set(:@@default, nil)


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Metrics for Availability_check:
* topological_inventory_amazon_operations:
  * _status_counter (args: operation name and result) [counter]
  * _duration_seconds [histogram]

---

* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/57
* [x] **blocked by** https://github.com/RedHatInsights/topological_inventory-amazon/pull/74


[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)