### PR TITLE
Bump providers-common to 2.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 2.1.1"
+gem "topological_inventory-providers-common", "~> 2.1.2"
 group :test, :development do
   gem "rspec"
   gem "rubocop",             "~> 1.0.0", :require => false


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-providers-common/issues/66

---

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)