### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Topological Inventory Amazon
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-amazon.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-amazon)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-amazon.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-amazon)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fd49345c28fa632ba2c6/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-amazon/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fd49345c28fa632ba2c6/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-amazon/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-amazon/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-amazon/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.